### PR TITLE
use underscore.js to clone the data object passed into delorean constructor

### DIFF
--- a/delorean.js
+++ b/delorean.js
@@ -291,7 +291,7 @@
 
         chart = $(target_);
         chart.children().remove();
-        data = data_;
+        data = _.clone(data_);
 
         var i = data.length;
 


### PR DESCRIPTION
Delorean makes some modifications to the `_data` parameter passed into the constructor, and because javascript variables are assigned by reference, this modifies the original object. Using `_.clone(obj)` leaves the original object unmodified.
